### PR TITLE
Remove wee_alloc.

### DIFF
--- a/lurk-snippet/Cargo.toml
+++ b/lurk-snippet/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["cdylib"]
 
 [features]
 # default = ["debug"]
-default = ["wee_alloc"]
 
 [dependencies]
 # The `wasm-bindgen` crate provides the bare minimum functionality needed
@@ -29,11 +28,6 @@ serde_json = "1.0"
 lurk = "0.1.1"
 blstrs = "0.5.0"
 parking_lot = { version = "0.12", features = ["nightly"] }
-
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. However, it is slower than the default
-# allocator, so it's not enabled by default.
-wee_alloc = { version = "0.4.2", optional = true }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
This PR (appears to) fix the observed problem that the opening a commitment leads to an error — even if the commitment is (or should be) known to the current evaluator.
